### PR TITLE
Add mesalib to requirements in environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -14,6 +14,7 @@ dependencies:
   - requests      # required to run demos
   - matplotlib    # required to run demos
   - jupyter
+  - mesalib       # needed by visvis - we should maybe remove as v heavy?
   - pip:
     - revrand==0.6.5
     - unipath     # required to run demos


### PR DESCRIPTION
Some of the vis code needs libGL which we install using the mesa version.
It's pretty heavy, and we should look at removing at some stage...